### PR TITLE
feat: Validate emails when asking to join league

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -29,10 +29,10 @@ class BaseException(Exception):
     status_code = FDNESC
     message = "Fun count does not exist"
 
-    def __init__(self, status_code=None, payload=None):
+    def __init__(self, status_code=None, payload=None, message=None):
         Exception.__init__(self)
 
-        self.message = self.message
+        self.message = self.message if message is None else message
         if status_code is not None:
             self.status_code = status_code
         self.payload = payload

--- a/api/tests/website/test_login.py
+++ b/api/tests/website/test_login.py
@@ -1,0 +1,37 @@
+import pytest
+from flask import url_for
+from datetime import datetime
+
+
+@pytest.mark.routes
+@pytest.mark.usefixtures('client')
+@pytest.mark.usefixtures('mlsb_app')
+def test_join_league_requires_an_email(mlsb_app, client):
+    """Test unable to send join league request with no email."""
+    with mlsb_app.app_context():
+        with client.session_transaction() as session:
+            session["oauth_email"] = None
+        url = url_for("website.join_league", year=datetime.now().year)
+        response = client.post(url, follow_redirects=True)
+        assert response.status_code == 400
+        assert "did not give an email" in str(response.data)
+
+
+@pytest.mark.routes
+@pytest.mark.parametrize("invalid_email", [
+    "@@dallas",
+    "Drop table",
+    "-1 SELECT"
+])
+@pytest.mark.usefixtures('client')
+@pytest.mark.usefixtures('mlsb_app')
+def test_join_league_requires_valid_email(mlsb_app, client, invalid_email):
+    """Test unable to create join league request with invalid email."""
+    with mlsb_app.app_context():
+        invalid_email = ''
+        with client.session_transaction() as session:
+            session["oauth_email"] = invalid_email
+        url = url_for("website.join_league", year=datetime.now().year)
+        response = client.post(url, follow_redirects=True)
+        assert response.status_code == 400
+        assert invalid_email in str(response.data)

--- a/api/website/login.py
+++ b/api/website/login.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Holds views related to login, authentication and join leagues"""
+from email.utils import parseaddr
 from flask import render_template, session, request, url_for, redirect
 from flask_login import \
     current_user, logout_user, login_required, login_user
@@ -17,7 +18,7 @@ from api.website import website_blueprint
 
 @website_blueprint.route("/authenticate")
 def need_to_login():
-    """A route used to indicate the user needs to authenicate for some page."""
+    """A route used to indicate the user needs to authenticate for some page."""
     year = date.today().year
     return render_template(
         "website/login.html",
@@ -60,10 +61,15 @@ def join_league():
     """A form submission to ask to join the league."""
     # ensure given an email
     email = session.get("oauth_email", None)
+    formatted_email = parseaddr(email)
     if email is None:
         # it should have been stored after authenicating
         message = "Sorry, the authentication provider did not give an email"
-        raise OAuthException(message)
+        raise OAuthException(message=message)
+    elif formatted_email[1] == '':
+        # it should have been stored after authenicating
+        message = f"Sorry, the given email - {email} seemed to be invalid"
+        raise OAuthException(message=message)
     # double check the player email has not be taken
     player = Player.query.filter(Player.email == email).first()
     if player is not None:


### PR DESCRIPTION
## Checklist

- [x] I have added the appropriate label to this PR ("bug", "feature")
- [x] I have assigned myself to this PR
- [x] I have performed a self-review of my code
- [x] I have tested my changes to the best of my abilities (not just unit tests, but integration/end-to-end tests as well)

## Issues closed

## Description

Validate the email is valid before allowing someone to create a join league request. A large number of requests with invalid emails. This should prevent that issue.